### PR TITLE
Update Naming API Endpoints in What-is-an-API.md

### DIFF
--- a/Session-02/What-is-an-API.md
+++ b/Session-02/What-is-an-API.md
@@ -255,7 +255,7 @@ We will know the state of the resource:
 | BAD                     | Good                              | HTTP      |
 | ----------------------- | --------------------------------- | --------- |
 | `getUsers`              | `/api/v1/users`                   | GET       |
-| `getUserById`           | `/api/v1users/{id}`               | GET       |
+| `getUserById`           | `/api/v1/users/{id}`              | GET       |
 | `getUsersV1`            | `/api/v1/users`                   | GET       |
 | `store-inventory`       | `/api/v2/inventories`             | POST      |
 | `updateUserByID`        | `/api/v1/users/{id}`              | PUT/PATCH |


### PR DESCRIPTION
Add missing '/' in the endpoint example.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request corrects a minor documentation error in 'What-is-an-API.md' by adding a missing '/' in the 'getUserById' endpoint example.

- **Documentation**:
    - Corrected the endpoint example in 'What-is-an-API.md' by adding a missing '/' in the 'getUserById' endpoint.

<!-- Generated by sourcery-ai[bot]: end summary -->